### PR TITLE
Add TextEstimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ root.add_child<SVG::Line>(
 
 ### Class Lists and Queries
 
+Attribute names are stored and looked up case-sensitively, matching SVG/XML behavior. Use the exact SVG spelling for mixed-case names such as `viewBox`; `viewbox` is a separate attribute and will not be used by SVG viewers as a substitute.
+
 `class_list()` treats the `class` attribute as a normalized token list, so repeated whitespace and duplicate class tokens are cleaned up. Use `get_elements_by_class()` when you want token-aware matches instead of substring checks.
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ label->layout_bbox({ -4, 96, -18, 6 });
 root.autoscale();
 ```
 
+Text layout bounds are estimates, not exact font shaping or browser measurements. The built-in estimator is UTF-8 aware, treats combining marks as zero-width, and uses conservative advances for ASCII, CJK/full-width text, emoji, and bold text. If an element only needs a little extra layout space, use `bbox_padding()`; an explicit `layout_bbox()` still takes precedence.
+
+```cpp
+title->bbox_padding({ 2, 2, 4, 4 });
+```
+
 Use `snap_to()` to position measured elements against each other with SVG transforms. Passing only `RelativeAlignment` uses `Anchor::Center`, so offsets do not require spelling out the center anchor. Combine the two enums with `|` when you need start or end alignment along the shared edge. Use `align_to()` when elements should share an axis without becoming neighbors.
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="examples/svg-open-sign.svg" alt="SVG for C++" width="680">
+  <img src="https://raw.githubusercontent.com/vincentlaucsb/svg/master/examples/svg-open-sign.svg" alt="SVG for C++" width="680">
   <br>
-  <a href="examples/open_sign.cpp">See the C++ code for this logo</a>
+  <a href="https://github.com/vincentlaucsb/svg/blob/master/examples/open_sign.cpp">See the C++ code for this logo</a>
   <br>
-  <a href="examples/svg-open-sign.svg"><img src="examples/svg-open-sign-swatch.svg" alt="pink logo" width="64"></a>
-  <a href="examples/svg-open-sign-green.svg"><img src="examples/svg-open-sign-green-swatch.svg" alt="green logo" width="64"></a>
-  <a href="examples/svg-open-sign-blue.svg"><img src="examples/svg-open-sign-blue-swatch.svg" alt="blue logo" width="64"></a>
-  <a href="examples/svg-open-sign-red.svg"><img src="examples/svg-open-sign-red-swatch.svg" alt="red logo" width="64"></a>
+  <a href="https://github.com/vincentlaucsb/svg/blob/master/examples/svg-open-sign.svg"><img src="https://raw.githubusercontent.com/vincentlaucsb/svg/master/examples/svg-open-sign-swatch.svg" alt="pink logo" width="64"></a>
+  <a href="https://github.com/vincentlaucsb/svg/blob/master/examples/svg-open-sign-green.svg"><img src="https://raw.githubusercontent.com/vincentlaucsb/svg/master/examples/svg-open-sign-green-swatch.svg" alt="green logo" width="64"></a>
+  <a href="https://github.com/vincentlaucsb/svg/blob/master/examples/svg-open-sign-blue.svg"><img src="https://raw.githubusercontent.com/vincentlaucsb/svg/master/examples/svg-open-sign-blue-swatch.svg" alt="blue logo" width="64"></a>
+  <a href="https://github.com/vincentlaucsb/svg/blob/master/examples/svg-open-sign-red.svg"><img src="https://raw.githubusercontent.com/vincentlaucsb/svg/master/examples/svg-open-sign-red-swatch.svg" alt="red logo" width="64"></a>
 </p>
 
 # SVG for C++

--- a/src/svg.hpp
+++ b/src/svg.hpp
@@ -45,6 +45,7 @@
 #include <math.h>    // NAN
 #include <map>
 #include <deque>
+#include <set>
 #include <vector>
 #include <string>
 #include <sstream> // stringstream
@@ -1393,14 +1394,14 @@ namespace SVG {
                 }
 
                 this->names_[key] = normalized_name;
-                this->used_names_[normalized_name] = key;
+                this->used_names_.insert(normalized_name);
             }
 
         private:
             /** Enum-to-name mapping for this helper. */
             std::map<T, std::string> names_;
-            /** Reverse map used to reject duplicate output names. */
-            std::map<std::string, T> used_names_;
+            /** Output names already assigned to an enum key. */
+            std::set<std::string> used_names_;
         };
     }
     /** @endcond */
@@ -3662,13 +3663,17 @@ namespace SVG {
                                       Axis axis,
                                       Anchor anchor,
                                       Point offset) {
+        if (axis != Axis::X && axis != Axis::Y) {
+            throw std::invalid_argument("align_to requires a valid axis");
+        }
+        if (anchor != Anchor::Start && anchor != Anchor::Center && anchor != Anchor::End) {
+            throw std::invalid_argument("align_to requires a valid anchor");
+        }
+
         const auto source_box = this->layout_bbox();
         const auto target_box = target.layout_bbox();
         if (!detail::bbox_is_measured(source_box) || !detail::bbox_is_measured(target_box)) {
             throw std::logic_error("align_to requires measured layout bounds");
-        }
-        if (anchor != Anchor::Start && anchor != Anchor::Center && anchor != Anchor::End) {
-            throw std::invalid_argument("align_to requires a valid anchor");
         }
 
         double dx = offset.first;

--- a/src/svg.hpp
+++ b/src/svg.hpp
@@ -465,6 +465,16 @@ namespace SVG {
             }
         }
 
+        template<typename T>
+        struct is_numeric_attr_type {
+            static const bool value =
+                std::is_arithmetic<T>::value &&
+                !std::is_same<typename std::remove_cv<T>::type, bool>::value &&
+                !std::is_same<typename std::remove_cv<T>::type, char>::value &&
+                !std::is_same<typename std::remove_cv<T>::type, signed char>::value &&
+                !std::is_same<typename std::remove_cv<T>::type, unsigned char>::value;
+        };
+
         inline std::vector<double> parse_transform_args(std::string args) {
             for (auto& ch : args) {
                 if (ch == ',') {
@@ -1243,6 +1253,15 @@ namespace SVG {
         std::string get_attr(const std::string& key, const std::string& fallback = "") const {
             const auto found = this->attr_.find(key);
             return found == this->attr_.end() ? fallback : found->second;
+        }
+
+        /** Return a numeric attribute value, or fallback when unset or not parseable as a number. */
+        template<typename T>
+        typename std::enable_if<detail::is_numeric_attr_type<T>::value, T>::type
+        get_attr(const std::string& key, T fallback) const {
+            const auto found = this->attr_.find(key);
+            if (found == this->attr_.end()) return fallback;
+            return static_cast<T>(detail::parse_number_or(found->second, static_cast<double>(fallback)));
         }
 
         template<typename T>
@@ -3057,11 +3076,6 @@ namespace SVG {
         std::unique_ptr<Element> clone_element_impl() const override {
             return clone_as<Text>();
         }
-
-    private:
-        double numeric_attr_or(const std::string& key, double fallback) const {
-            return detail::parse_number_or(this->get_attr(key), fallback);
-        }
     };
 
     /** Native SVG title element whose content is XML-escaped when serialized. */
@@ -3205,16 +3219,16 @@ namespace SVG {
 
     inline Element::BoundingBox Text::get_bbox() const {
         if (content.empty()) {
-            const auto x = numeric_attr_or("x", 0) + numeric_attr_or("dx", 0);
-            const auto y = numeric_attr_or("y", 0) + numeric_attr_or("dy", 0);
+            const auto x = get_attr<double>("x", 0) + get_attr<double>("dx", 0);
+            const auto y = get_attr<double>("y", 0) + get_attr<double>("dy", 0);
             return include_stroke_width({ x, x, y, y });
         }
 
-        double font_size = numeric_attr_or("font-size", 16);
+        double font_size = get_attr<double>("font-size", 16);
         if (!(font_size > 0)) font_size = 16;
 
-        const double x = numeric_attr_or("x", 0) + numeric_attr_or("dx", 0);
-        const double y = numeric_attr_or("y", 0) + numeric_attr_or("dy", 0);
+        const double x = get_attr<double>("x", 0) + get_attr<double>("dx", 0);
+        const double y = get_attr<double>("y", 0) + get_attr<double>("dy", 0);
         const auto metrics = detail::TextEstimator(content, font_size, get_attr("font-weight")).estimate();
         const double width = metrics.width;
         const double height = metrics.height;
@@ -3465,7 +3479,7 @@ namespace SVG {
             const auto stroke = element.get_attr("stroke");
             if (stroke.empty() || stroke == "none") return 0;
 
-            const auto width = parse_number_or(element.get_attr("stroke-width"), 1);
+            const auto width = element.get_attr<double>("stroke-width", 1);
             return width > 0 ? width : 0;
         }
 
@@ -3541,10 +3555,10 @@ namespace SVG {
         Element::BoundingBox bbox = referenced->layout_bbox();
         if (!detail::bbox_is_measured(bbox)) return bbox;
 
-        const auto x = detail::parse_number_or(this->get_attr("x"), 0);
-        const auto y = detail::parse_number_or(this->get_attr("y"), 0);
-        const auto width = detail::parse_number_or(this->get_attr("width"), NAN);
-        const auto height = detail::parse_number_or(this->get_attr("height"), NAN);
+        const auto x = this->get_attr<double>("x", 0);
+        const auto y = this->get_attr<double>("y", 0);
+        const auto width = this->get_attr<double>("width", NAN);
+        const auto height = this->get_attr<double>("height", NAN);
         const auto viewbox = detail::parse_transform_args(referenced->get_attr("viewBox"));
         if (!std::isnan(width) && !std::isnan(height) && viewbox.size() == 4 &&
                 viewbox[2] != 0 && viewbox[3] != 0) {
@@ -3564,10 +3578,10 @@ namespace SVG {
     }
 
     inline Element::BoundingBox SVG::get_bbox() const {
-        const double x = detail::parse_number_or(this->get_attr("x"), 0);
-        const double y = detail::parse_number_or(this->get_attr("y"), 0);
-        const double width = detail::parse_number_or(this->get_attr("width"), NAN);
-        const double height = detail::parse_number_or(this->get_attr("height"), NAN);
+        const double x = this->get_attr<double>("x", 0);
+        const double y = this->get_attr<double>("y", 0);
+        const double width = this->get_attr<double>("width", NAN);
+        const double height = this->get_attr<double>("height", NAN);
 
         if (!std::isnan(width) && !std::isnan(height)) {
             return { x, x + width, y, y + height };

--- a/src/svg.hpp
+++ b/src/svg.hpp
@@ -5,7 +5,7 @@
    ___) | \ V /| |_| |
   |____/   \_/  \____|
 
-  SVG for C++ v0.4.0
+  SVG for C++ v0.5.0
 
   Copyright (c) 2018-2026 Vincent La
   SPDX-License-Identifier: MIT

--- a/src/svg.hpp
+++ b/src/svg.hpp
@@ -66,7 +66,6 @@ namespace SVG {
     class RadialGradient;
     class SVG;
     class Shape;
-    class Stop;
     class Symbol;
     class Use;
 
@@ -480,6 +479,252 @@ namespace SVG {
             }
             return values;
         }
+
+        class TextEstimator {
+        public:
+            struct Metrics {
+                double width = 0;
+                double height = 0;
+                double ascent = 0;
+                double descent = 0;
+            };
+
+            TextEstimator(std::string text_, double font_size_, std::string font_weight_) :
+                    text(std::move(text_)),
+                    font_size(font_size_ > 0 ? font_size_ : 16),
+                    font_weight(std::move(font_weight_)) {}
+
+            /** Estimated layout metrics only; this does not perform font shaping or browser measurement. */
+            Metrics estimate() const {
+                const auto bold = is_bold();
+                const double weight_multiplier = bold ? 1.06 : 1.0;
+                const double side_padding = bold ? font_size * 0.05 : font_size * 0.02;
+                const double vertical_padding = bold ? font_size * 0.10 : font_size * 0.06;
+                const double line_height = font_size * (bold ? 1.38 : 1.32);
+                const double ascent = font_size * (bold ? 1.00 : 0.96) + vertical_padding;
+                const double descent = font_size * (bold ? 0.38 : 0.34) + vertical_padding;
+
+                double current = 0;
+                double longest = 0;
+                std::size_t lines = text.empty() ? 0 : 1;
+                bool previous_was_joiner = false;
+                bool regional_pair_open = false;
+                std::size_t index = 0;
+
+                while (index < text.size()) {
+                    const auto codepoint = next_codepoint(index);
+                    if (codepoint == '\r') {
+                        if (index < text.size() && text[index] == '\n') ++index;
+                        longest = std::max(longest, current);
+                        current = 0;
+                        ++lines;
+                        previous_was_joiner = false;
+                        regional_pair_open = false;
+                        continue;
+                    }
+                    if (codepoint == '\n') {
+                        longest = std::max(longest, current);
+                        current = 0;
+                        ++lines;
+                        previous_was_joiner = false;
+                        regional_pair_open = false;
+                        continue;
+                    }
+
+                    current += glyph_advance(codepoint, previous_was_joiner, regional_pair_open);
+                    previous_was_joiner = codepoint == 0x200d;
+                }
+
+                longest = std::max(longest, current);
+                Metrics metrics;
+                metrics.width = longest == 0 ? 0 : longest * font_size * weight_multiplier + side_padding * 2;
+                metrics.ascent = ascent;
+                metrics.descent = descent;
+                metrics.height = lines == 0 ? 0 : ascent + descent + static_cast<double>(lines - 1) * line_height;
+                return metrics;
+            }
+
+        private:
+            std::string text;
+            double font_size;
+            std::string font_weight;
+
+            bool is_bold() const {
+                auto value = font_weight;
+                for (auto& ch : value) ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+                if (value == "bold" || value == "bolder") return true;
+                return parse_number_or(value, 400) >= 600;
+            }
+
+            uint32_t next_codepoint(std::size_t& index) const {
+                const auto first = static_cast<unsigned char>(text[index++]);
+                if (first < 0x80) return first;
+
+                uint32_t codepoint = 0xfffd;
+                std::size_t continuation_count = 0;
+                if ((first & 0xe0) == 0xc0) {
+                    codepoint = first & 0x1f;
+                    continuation_count = 1;
+                } else if ((first & 0xf0) == 0xe0) {
+                    codepoint = first & 0x0f;
+                    continuation_count = 2;
+                } else if ((first & 0xf8) == 0xf0) {
+                    codepoint = first & 0x07;
+                    continuation_count = 3;
+                } else {
+                    return 0xfffd;
+                }
+
+                for (std::size_t i = 0; i < continuation_count; ++i) {
+                    if (index >= text.size()) return 0xfffd;
+                    const auto next = static_cast<unsigned char>(text[index]);
+                    if ((next & 0xc0) != 0x80) return 0xfffd;
+                    ++index;
+                    codepoint = (codepoint << 6) | (next & 0x3f);
+                }
+
+                if ((continuation_count == 1 && codepoint < 0x80) ||
+                    (continuation_count == 2 && codepoint < 0x800) ||
+                    (continuation_count == 3 && codepoint < 0x10000) ||
+                    codepoint > 0x10ffff ||
+                    (codepoint >= 0xd800 && codepoint <= 0xdfff)) {
+                    return 0xfffd;
+                }
+                return codepoint;
+            }
+
+            static bool in_range(uint32_t value, uint32_t first, uint32_t last) {
+                return value >= first && value <= last;
+            }
+
+            static bool is_combining_mark(uint32_t codepoint) {
+                return in_range(codepoint, 0x0300, 0x036f) ||
+                       in_range(codepoint, 0x0483, 0x0489) ||
+                       in_range(codepoint, 0x0591, 0x05bd) ||
+                       codepoint == 0x05bf ||
+                       in_range(codepoint, 0x05c1, 0x05c2) ||
+                       in_range(codepoint, 0x05c4, 0x05c5) ||
+                       codepoint == 0x05c7 ||
+                       in_range(codepoint, 0x0610, 0x061a) ||
+                       in_range(codepoint, 0x064b, 0x065f) ||
+                       codepoint == 0x0670 ||
+                       in_range(codepoint, 0x06d6, 0x06dc) ||
+                       in_range(codepoint, 0x06df, 0x06e4) ||
+                       in_range(codepoint, 0x06e7, 0x06e8) ||
+                       in_range(codepoint, 0x06ea, 0x06ed) ||
+                       in_range(codepoint, 0x1ab0, 0x1aff) ||
+                       in_range(codepoint, 0x1dc0, 0x1dff) ||
+                       in_range(codepoint, 0x20d0, 0x20ff) ||
+                       in_range(codepoint, 0xfe20, 0xfe2f);
+            }
+
+            static bool is_variation_selector(uint32_t codepoint) {
+                return in_range(codepoint, 0xfe00, 0xfe0f) ||
+                       in_range(codepoint, 0xe0100, 0xe01ef);
+            }
+
+            static bool is_full_width(uint32_t codepoint) {
+                return in_range(codepoint, 0x1100, 0x115f) ||
+                       in_range(codepoint, 0x2329, 0x232a) ||
+                       in_range(codepoint, 0x2e80, 0xa4cf) ||
+                       in_range(codepoint, 0xac00, 0xd7a3) ||
+                       in_range(codepoint, 0xf900, 0xfaff) ||
+                       in_range(codepoint, 0xfe10, 0xfe19) ||
+                       in_range(codepoint, 0xfe30, 0xfe6f) ||
+                       in_range(codepoint, 0xff00, 0xff60) ||
+                       in_range(codepoint, 0xffe0, 0xffe6);
+            }
+
+            static bool is_emoji_or_symbol(uint32_t codepoint) {
+                return in_range(codepoint, 0x1f000, 0x1faff) ||
+                       in_range(codepoint, 0x2600, 0x27bf) ||
+                       in_range(codepoint, 0x2190, 0x21ff) ||
+                       in_range(codepoint, 0x2300, 0x23ff);
+            }
+
+            static bool is_regional_indicator(uint32_t codepoint) {
+                return in_range(codepoint, 0x1f1e6, 0x1f1ff);
+            }
+
+            static bool is_latin_letter(uint32_t codepoint) {
+                return in_range(codepoint, 'A', 'Z') ||
+                       in_range(codepoint, 'a', 'z') ||
+                       in_range(codepoint, 0x00c0, 0x024f);
+            }
+
+            static double ascii_advance(uint32_t codepoint) {
+                switch (codepoint) {
+                    case ' ':
+                    case '\t':
+                    case '.':
+                    case ',':
+                    case ':':
+                    case ';':
+                    case '\'':
+                    case '"':
+                    case '`':
+                    case '!':
+                    case '|':
+                        return 0.34;
+                    case 'i':
+                    case 'j':
+                    case 'l':
+                    case 'I':
+                    case '[':
+                    case ']':
+                    case '(':
+                    case ')':
+                    case '{':
+                    case '}':
+                        return 0.40;
+                    case 'm':
+                    case 'w':
+                    case 'M':
+                    case 'W':
+                    case '@':
+                    case '%':
+                    case '&':
+                        return 0.92;
+                    case '-':
+                    case '_':
+                    case '/':
+                    case '\\':
+                        return 0.52;
+                    default:
+                        break;
+                }
+
+                if (in_range(codepoint, '0', '9')) return 0.64;
+                if (in_range(codepoint, 'A', 'Z')) return 0.72;
+                if (in_range(codepoint, 'a', 'z')) return 0.62;
+                return 0.58;
+            }
+
+            static double glyph_advance(uint32_t codepoint,
+                                        bool previous_was_joiner,
+                                        bool& regional_pair_open) {
+                if (is_combining_mark(codepoint) ||
+                    is_variation_selector(codepoint) ||
+                    codepoint == 0x200d ||
+                    in_range(codepoint, 0x1f3fb, 0x1f3ff)) {
+                    return 0;
+                }
+
+                if (previous_was_joiner) return 0;
+
+                if (is_regional_indicator(codepoint)) {
+                    regional_pair_open = !regional_pair_open;
+                    return regional_pair_open ? 1.10 : 0;
+                }
+                regional_pair_open = false;
+
+                if (codepoint < 0x80) return ascii_advance(codepoint);
+                if (is_full_width(codepoint)) return 1.05;
+                if (is_emoji_or_symbol(codepoint)) return 1.10;
+                if (is_latin_letter(codepoint)) return 0.66;
+                return 0.85;
+            }
+        };
 
         inline AffineTransform parse_supported_transform(const std::string& transform) {
             AffineTransform current;
@@ -1120,41 +1365,45 @@ namespace SVG {
         return *this;
     }
 
-    /** Shared enum-to-string map for typed CSS helpers. */
-    template<typename T>
-    class TypedNames {
-        static_assert(std::is_enum<T>::value, "Typed CSS keys must be an enum type.");
+    /** @cond */
+    namespace detail {
+        /** Shared enum-to-string map for typed CSS helpers. */
+        template<typename T>
+        class TypedNames {
+            static_assert(std::is_enum<T>::value, "Typed CSS keys must be an enum type.");
 
-    public:
-        /** Return the canonical CSS name for a typed key. */
-        std::string name(T key) const {
-            const auto found = this->names_.find(key);
-            if (found == this->names_.end()) {
-                throw std::invalid_argument("Unknown typed CSS key");
-            }
-            return found->second;
-        }
-
-    protected:
-        /** Add one validated typed key/name pair. */
-        void add_name(T key, const std::string& normalized_name, const std::string& duplicate_label) {
-            if (this->names_.find(key) != this->names_.end()) {
-                throw std::invalid_argument("Duplicate typed CSS key");
-            }
-            if (this->used_names_.find(normalized_name) != this->used_names_.end()) {
-                throw std::invalid_argument("Duplicate " + duplicate_label + ": " + normalized_name);
+        public:
+            /** Return the canonical CSS name for a typed key. */
+            std::string name(T key) const {
+                const auto found = this->names_.find(key);
+                if (found == this->names_.end()) {
+                    throw std::invalid_argument("Unknown typed CSS key");
+                }
+                return found->second;
             }
 
-            this->names_[key] = normalized_name;
-            this->used_names_[normalized_name] = key;
-        }
+        protected:
+            /** Add one validated typed key/name pair. */
+            void add_name(T key, const std::string& normalized_name, const std::string& duplicate_label) {
+                if (this->names_.find(key) != this->names_.end()) {
+                    throw std::invalid_argument("Duplicate typed CSS key");
+                }
+                if (this->used_names_.find(normalized_name) != this->used_names_.end()) {
+                    throw std::invalid_argument("Duplicate " + duplicate_label + ": " + normalized_name);
+                }
 
-    private:
-        /** Enum-to-name mapping for this helper. */
-        std::map<T, std::string> names_;
-        /** Reverse map used to reject duplicate output names. */
-        std::map<std::string, T> used_names_;
-    };
+                this->names_[key] = normalized_name;
+                this->used_names_[normalized_name] = key;
+            }
+
+        private:
+            /** Enum-to-name mapping for this helper. */
+            std::map<T, std::string> names_;
+            /** Reverse map used to reject duplicate output names. */
+            std::map<std::string, T> used_names_;
+        };
+    }
+    /** @endcond */
 
     /** Mapping entry for a typed CSS custom property, optionally with an initial value. */
     template<typename T>
@@ -1195,7 +1444,7 @@ namespace SVG {
 
     /** Typed helper for defining and referencing CSS custom properties without stringly lookups. */
     template<typename T>
-    class Variables : public TypedNames<T> {
+    class Variables : public detail::TypedNames<T> {
     public:
         /** Validate the enum-to-name map and apply any initial values to the target style block. */
         Variables(AttributeMap& target, std::initializer_list<VariableSpec<T>> specs) :
@@ -1302,7 +1551,7 @@ namespace SVG {
 
     /** Typed helper for building class attributes and class selectors without stringly lookups. */
     template<typename T>
-    class Classes : public TypedNames<T> {
+    class Classes : public detail::TypedNames<T> {
     public:
         /** Validate and register typed CSS class tokens. */
         Classes(std::initializer_list<ClassSpec<T>> specs) {
@@ -1408,7 +1657,8 @@ namespace SVG {
                 owner_(nullptr),
                 indexed_id_(),
                 has_layout_bbox_(other.has_layout_bbox_),
-                layout_bbox_(other.layout_bbox_) {
+                layout_bbox_(other.layout_bbox_),
+                layout_bbox_padding_(other.layout_bbox_padding_) {
             other.has_layout_bbox_ = false;
             reparent_children();
         }
@@ -1422,6 +1672,7 @@ namespace SVG {
                 indexed_id_.clear();
                 has_layout_bbox_ = other.has_layout_bbox_;
                 layout_bbox_ = other.layout_bbox_;
+                layout_bbox_padding_ = other.layout_bbox_padding_;
                 other.has_layout_bbox_ = false;
                 reparent_children();
             }
@@ -1528,6 +1779,10 @@ namespace SVG {
         void responsive_autoscale(const AutoscaleOptions& options);
         /** Provide explicit bounds for autoscale/layout when built-in measurement is insufficient. */
         Element& layout_bbox(const BoundingBox& bbox);
+        /** Inflate measured autoscale/layout bounds; explicit layout_bbox() overrides this padding. */
+        Element& bbox_padding(const Margins& padding);
+        /** Inflate measured autoscale/layout bounds equally on every side. */
+        Element& bbox_padding(double padding);
         /** Remove an explicit autoscale/layout bound override. */
         Element& clear_layout_bbox();
         /** Return true when autoscale/layout uses caller-provided bounds for this element. */
@@ -1666,6 +1921,7 @@ namespace SVG {
         std::string indexed_id_;
         bool has_layout_bbox_ = false;
         BoundingBox layout_bbox_ = BoundingBox(NAN, NAN, NAN, NAN);
+        Margins layout_bbox_padding_ = NO_MARGINS;
     };
 
     template<>
@@ -1740,7 +1996,8 @@ namespace SVG {
             owner_(nullptr),
             indexed_id_(),
             has_layout_bbox_(other.has_layout_bbox_),
-            layout_bbox_(other.layout_bbox_) {
+            layout_bbox_(other.layout_bbox_),
+            layout_bbox_padding_(other.layout_bbox_padding_) {
         for (const auto& child : other.children) {
             this->insert_child(child->clone_element(), this->children.end());
         }
@@ -2083,89 +2340,93 @@ namespace SVG {
         std::unique_ptr<Element> clone_element_impl() const override { return clone_as<Defs>(); }
     };
 
-    /** Gradient color stop managed by LinearGradient and RadialGradient builders. */
-    class Stop : public Element {
-    public:
-        static constexpr ElementKind static_kind = ElementKind::Stop;
-        Stop() = default;
-        using Element::Element;
-        ElementKind kind() const override { return static_kind; }
+    /** @cond */
+    namespace detail {
+        /** Gradient color stop managed by LinearGradient and RadialGradient builders. */
+        class Stop : public Element {
+        public:
+            static constexpr ElementKind static_kind = ElementKind::Stop;
+            Stop() = default;
+            using Element::Element;
+            ElementKind kind() const override { return static_kind; }
 
-        Stop(std::string offset, std::string color) {
-            this->set_attr("offset", std::move(offset));
-            this->set_attr("stop-color", std::move(color));
-        }
-
-        Stop(std::string offset, std::string color, double opacity) :
-                Stop(std::move(offset), std::move(color)) {
-            this->set_attr("stop-opacity", opacity);
-        }
-
-    protected:
-        std::unique_ptr<Element> clone_element_impl() const override { return clone_as<Stop>(); }
-    };
-
-    /** Shared builder implementation for SVG gradient definitions. */
-    class GradientElement : public Element {
-    public:
-        using Element::Element;
-
-        /** Return the paint server URL for fill or stroke attributes. */
-        std::string url() const {
-            const auto gradient_id = this->id();
-            if (gradient_id.empty()) {
-                throw std::logic_error("SVG gradient must have an id before it can be referenced");
-            }
-            return "url(#" + gradient_id + ")";
-        }
-
-    protected:
-        void add_stop(std::string offset, std::string color) {
-            this->add_child<Stop>(std::move(offset), std::move(color));
-        }
-
-        void add_stop(std::string offset, std::string color, double opacity) {
-            this->add_child<Stop>(std::move(offset), std::move(color), opacity);
-        }
-
-        void set_solid_segments(std::initializer_list<std::string> colors) {
-            if (colors.size() == 0) {
-                throw std::invalid_argument("solid_segments requires at least one color");
+            Stop(std::string offset, std::string color) {
+                this->set_attr("offset", std::move(offset));
+                this->set_attr("stop-color", std::move(color));
             }
 
-            this->clear_children();
-            if (colors.size() == 1) {
-                const auto color = *colors.begin();
-                add_stop("0%", color);
-                add_stop("100%", color);
-                return;
+            Stop(std::string offset, std::string color, double opacity) :
+                    Stop(std::move(offset), std::move(color)) {
+                this->set_attr("stop-opacity", opacity);
             }
 
-            const auto segment_width = 100.0 / static_cast<double>(colors.size());
-            std::size_t index = 0;
-            for (const auto& color : colors) {
-                const auto start = percent(index * segment_width);
-                const auto end = percent((index + 1) * segment_width);
-                add_stop(start, color);
-                add_stop(end, color);
-                ++index;
-            }
-        }
+        protected:
+            std::unique_ptr<Element> clone_element_impl() const override { return clone_as<Stop>(); }
+        };
 
-    private:
-        static std::string percent(double value) {
-            std::stringstream ss;
-            ss << std::fixed << std::setprecision(1) << value << "%";
-            return ss.str();
-        }
-    };
+        /** Shared builder implementation for SVG gradient definitions. */
+        class GradientElement : public Element {
+        public:
+            using Element::Element;
+
+            /** Return the paint server URL for fill or stroke attributes. */
+            std::string url() const {
+                const auto gradient_id = this->id();
+                if (gradient_id.empty()) {
+                    throw std::logic_error("SVG gradient must have an id before it can be referenced");
+                }
+                return "url(#" + gradient_id + ")";
+            }
+
+        protected:
+            void add_stop(std::string offset, std::string color) {
+                this->add_child<Stop>(std::move(offset), std::move(color));
+            }
+
+            void add_stop(std::string offset, std::string color, double opacity) {
+                this->add_child<Stop>(std::move(offset), std::move(color), opacity);
+            }
+
+            void set_solid_segments(std::initializer_list<std::string> colors) {
+                if (colors.size() == 0) {
+                    throw std::invalid_argument("solid_segments requires at least one color");
+                }
+
+                this->clear_children();
+                if (colors.size() == 1) {
+                    const auto color = *colors.begin();
+                    add_stop("0%", color);
+                    add_stop("100%", color);
+                    return;
+                }
+
+                const auto segment_width = 100.0 / static_cast<double>(colors.size());
+                std::size_t index = 0;
+                for (const auto& color : colors) {
+                    const auto start = percent(index * segment_width);
+                    const auto end = percent((index + 1) * segment_width);
+                    add_stop(start, color);
+                    add_stop(end, color);
+                    ++index;
+                }
+            }
+
+        private:
+            static std::string percent(double value) {
+                std::stringstream ss;
+                ss << std::fixed << std::setprecision(1) << value << "%";
+                return ss.str();
+            }
+        };
+    }
+    /** @endcond */
 
     /** Linear gradient definition created through Defs::linear_gradient(). */
-    class LinearGradient : public GradientElement {
+    class LinearGradient : public detail::GradientElement {
     public:
         static constexpr ElementKind static_kind = ElementKind::LinearGradient;
         LinearGradient() = default;
-        using GradientElement::GradientElement;
+        using detail::GradientElement::GradientElement;
         ElementKind kind() const override { return static_kind; }
 
         explicit LinearGradient(std::string id) {
@@ -2216,11 +2477,11 @@ namespace SVG {
     };
 
     /** Radial gradient definition created through Defs::radial_gradient(). */
-    class RadialGradient : public GradientElement {
+    class RadialGradient : public detail::GradientElement {
     public:
         static constexpr ElementKind static_kind = ElementKind::RadialGradient;
         RadialGradient() = default;
-        using GradientElement::GradientElement;
+        using detail::GradientElement::GradientElement;
         ElementKind kind() const override { return static_kind; }
 
         explicit RadialGradient(std::string id) {
@@ -2797,43 +3058,8 @@ namespace SVG {
         }
 
     private:
-        static double parse_numeric_or(const std::string& value, double fallback) {
-            if (value.empty()) return fallback;
-            try {
-                return std::stof(value);
-            } catch (const std::invalid_argument&) {
-                return fallback;
-            } catch (const std::out_of_range&) {
-                return fallback;
-            }
-        }
-
         double numeric_attr_or(const std::string& key, double fallback) const {
-            return parse_numeric_or(this->get_attr(key), fallback);
-        }
-
-        static std::size_t line_count(const std::string& text) {
-            if (text.empty()) return 0;
-            std::size_t count = 1;
-            for (const auto ch : text) {
-                if (ch == '\n') ++count;
-            }
-            return count;
-        }
-
-        static std::size_t max_line_codepoints(const std::string& text) {
-            std::size_t current = 0;
-            std::size_t longest = 0;
-            for (const auto ch : text) {
-                if (ch == '\n') {
-                    if (current > longest) longest = current;
-                    current = 0;
-                    continue;
-                }
-                const auto byte = static_cast<unsigned char>(ch);
-                if ((byte & 0xc0) != 0x80) ++current;
-            }
-            return current > longest ? current : longest;
+            return detail::parse_number_or(this->get_attr(key), fallback);
         }
     };
 
@@ -2988,8 +3214,9 @@ namespace SVG {
 
         const double x = numeric_attr_or("x", 0) + numeric_attr_or("dx", 0);
         const double y = numeric_attr_or("y", 0) + numeric_attr_or("dy", 0);
-        const double width = static_cast<double>(max_line_codepoints(content)) * font_size * 0.6;
-        const double height = static_cast<double>(line_count(content)) * font_size * 1.2;
+        const auto metrics = detail::TextEstimator(content, font_size, get_attr("font-weight")).estimate();
+        const double width = metrics.width;
+        const double height = metrics.height;
 
         double x1 = x;
         const auto anchor = this->get_attr("text-anchor", "start");
@@ -3002,7 +3229,7 @@ namespace SVG {
         const auto baseline = this->get_attr(
             "dominant-baseline",
             this->get_attr("alignment-baseline", "alphabetic"));
-        double y1 = y - font_size * 0.8;
+        double y1 = y - metrics.ascent;
         if (baseline == "middle" || baseline == "central" || baseline == "mathematical") {
             y1 = y - height / 2;
         } else if (baseline == "hanging" || baseline == "text-before-edge" || baseline == "text-top") {
@@ -3174,6 +3401,15 @@ namespace SVG {
         return *this;
     }
 
+    inline Element& Element::bbox_padding(const Margins& padding) {
+        layout_bbox_padding_ = padding;
+        return *this;
+    }
+
+    inline Element& Element::bbox_padding(double padding) {
+        return bbox_padding({ padding, padding, padding, padding });
+    }
+
     inline Element& Element::clear_layout_bbox() {
         has_layout_bbox_ = false;
         layout_bbox_ = BoundingBox(NAN, NAN, NAN, NAN);
@@ -3185,7 +3421,18 @@ namespace SVG {
     }
 
     inline Element::BoundingBox Element::measured_layout_bbox() const {
-        return has_layout_bbox_ ? layout_bbox_ : this->get_bbox();
+        if (has_layout_bbox_) return layout_bbox_;
+        auto bbox = this->get_bbox();
+        if (std::isnan(bbox.x1) || std::isnan(bbox.x2) ||
+            std::isnan(bbox.y1) || std::isnan(bbox.y2)) {
+            return bbox;
+        }
+        return {
+            bbox.x1 - layout_bbox_padding_.x1,
+            bbox.x2 + layout_bbox_padding_.x2,
+            bbox.y1 - layout_bbox_padding_.y1,
+            bbox.y2 + layout_bbox_padding_.y2
+        };
     }
 
     inline detail::AffineTransform Element::transform_for(
@@ -3513,7 +3760,7 @@ namespace SVG {
         /** Automatically set the width, height, and viewBox attribute of this item
          *  so that it can contain all of its children without clipping
          *
-         *  @param[in] margins Extra margins for the sides
+         *  @param[in] options Margins and nested SVG autoscale behavior
          */
         if (options.autoscale_nested_svgs) {
             this->autoscale_nested_svgs(options, false);

--- a/tests/class_list_tests.cpp
+++ b/tests/class_list_tests.cpp
@@ -74,6 +74,20 @@ TEST_CASE("set_attrs applies multiple attributes and normalizes class values", "
     REQUIRE(rect.attrs().size() == 3);
 }
 
+TEST_CASE("get_attr supports string and numeric fallbacks", "[attributes]") {
+    SVG::Rect rect;
+    rect.set_attr("x", "12.5px")
+        .set_attr("data-count", "7")
+        .set_attr("data-bad-number", "calc(100% - 2px)");
+
+    REQUIRE(rect.get_attr("x", "0") == "12.5px");
+    REQUIRE(rect.get_attr("missing", "fallback") == "fallback");
+    REQUIRE(rect.get_attr<double>("x", 0) == Approx(12.5));
+    REQUIRE(rect.get_attr<int>("data-count", 0) == 7);
+    REQUIRE(rect.get_attr<double>("missing-number", 4.5) == Approx(4.5));
+    REQUIRE(rect.get_attr<double>("data-bad-number", 2.5) == Approx(2.5));
+}
+
 TEST_CASE("TransformList appends transform functions in order", "[transform-list]") {
     SVG::Text label(10, 20, "Workout");
 

--- a/tests/layout_tests.cpp
+++ b/tests/layout_tests.cpp
@@ -142,7 +142,7 @@ TEST_CASE("rotate_about_bbox rotates text around bottom-right bounds", "[layout]
 
     label.transform().rotate_about_bbox(-45, SVG::Anchor::End, SVG::Anchor::End);
 
-    REQUIRE(label.get_attr("transform").find("rotate(-45.0 28.0 24.0)") != std::string::npos);
+    REQUIRE(label.get_attr("transform").find("rotate(-45.0 32.0 24.0)") != std::string::npos);
 }
 
 TEST_CASE("autoscale includes text rotated around its measured bbox", "[layout]") {
@@ -153,7 +153,7 @@ TEST_CASE("autoscale includes text rotated around its measured bbox", "[layout]"
 
     root.autoscale(SVG::NO_MARGINS);
 
-    REQUIRE(root.get_attr("viewBox") == "16.0 24.0 12.0 18.0");
+    REQUIRE(root.get_attr("viewBox") == "17.8 24.0 14.2 22.0");
 }
 
 TEST_CASE("rotate_about_bbox supports rect bounds", "[layout]") {
@@ -256,8 +256,8 @@ TEST_CASE("text bbox approximates baseline text bounds", "[layout]") {
     const auto bbox = label.get_bbox();
 
     REQUIRE(bbox.x1 == Approx(10));
-    REQUIRE(bbox.x2 == Approx(28));
-    REQUIRE(bbox.y1 == Approx(12));
+    REQUIRE(bbox.x2 == Approx(32));
+    REQUIRE(bbox.y1 == Approx(9.8));
     REQUIRE(bbox.y2 == Approx(24));
 }
 
@@ -269,10 +269,10 @@ TEST_CASE("text bbox respects middle anchor and baseline", "[layout]") {
 
     const auto bbox = title.get_bbox();
 
-    REQUIRE(bbox.x1 == Approx(14));
-    REQUIRE(bbox.x2 == Approx(86));
-    REQUIRE(bbox.y1 == Approx(13));
-    REQUIRE(bbox.y2 == Approx(37));
+    REQUIRE(bbox.x1 == Approx(11.4));
+    REQUIRE(bbox.x2 == Approx(88.6));
+    REQUIRE(bbox.y1 == Approx(10.8));
+    REQUIRE(bbox.y2 == Approx(39.2));
 }
 
 TEST_CASE("text bbox falls back for non-numeric font sizes", "[layout]") {
@@ -281,8 +281,76 @@ TEST_CASE("text bbox falls back for non-numeric font sizes", "[layout]") {
 
     const auto bbox = label.get_bbox();
 
-    REQUIRE(bbox.x2 - bbox.x1 == Approx(19.2));
-    REQUIRE(bbox.y2 - bbox.y1 == Approx(19.2));
+    REQUIRE(bbox.x2 - bbox.x1 == Approx(23.68));
+    REQUIRE(bbox.y2 - bbox.y1 == Approx(22.72));
+}
+
+TEST_CASE("text bbox distinguishes narrow and wide ASCII advances", "[layout]") {
+    SVG::Text narrow(0, 0, "ill...");
+    SVG::Text wide(0, 0, "MWm");
+    narrow.set_attr("font-size", 10);
+    wide.set_attr("font-size", 10);
+
+    const auto narrow_bbox = narrow.get_bbox();
+    const auto wide_bbox = wide.get_bbox();
+
+    REQUIRE(narrow_bbox.x2 - narrow_bbox.x1 == Approx(22.6));
+    REQUIRE(wide_bbox.x2 - wide_bbox.x1 == Approx(28));
+}
+
+TEST_CASE("large bold text bbox is padded conservatively", "[layout]") {
+    SVG::Text normal(0, 100, "MWM Title");
+    SVG::Text bold(0, 100, "MWM Title");
+    normal.set_attr("font-size", 100);
+    bold.set_attr("font-size", 100)
+        .set_attr("font-weight", "bold");
+
+    const auto normal_bbox = normal.get_bbox();
+    const auto bold_bbox = bold.get_bbox();
+
+    REQUIRE(bold_bbox.x2 - bold_bbox.x1 > normal_bbox.x2 - normal_bbox.x1);
+    REQUIRE(bold_bbox.y2 - bold_bbox.y1 > normal_bbox.y2 - normal_bbox.y1);
+    REQUIRE(bold_bbox.y1 < 0);
+    REQUIRE(bold_bbox.y2 > 140);
+}
+
+TEST_CASE("text bbox decodes UTF-8 accented text by code point", "[layout]") {
+    SVG::Text label(0, 0, std::string("caf\xc3\xa9"));
+    label.set_attr("font-size", 10);
+
+    const auto bbox = label.get_bbox();
+
+    REQUIRE(bbox.x2 - bbox.x1 == Approx(25.6));
+}
+
+TEST_CASE("text bbox gives combining marks zero advance", "[layout]") {
+    SVG::Text plain(0, 0, "e");
+    SVG::Text combining(0, 0, std::string("e\xcc\x81"));
+    plain.set_attr("font-size", 10);
+    combining.set_attr("font-size", 10);
+
+    const auto plain_bbox = plain.get_bbox();
+    const auto combining_bbox = combining.get_bbox();
+
+    REQUIRE(combining_bbox.x2 - combining_bbox.x1 == Approx(plain_bbox.x2 - plain_bbox.x1));
+}
+
+TEST_CASE("text bbox estimates CJK characters as full-width", "[layout]") {
+    SVG::Text label(0, 0, std::string("\xe6\x96\x87\xe6\x9c\xac"));
+    label.set_attr("font-size", 10);
+
+    const auto bbox = label.get_bbox();
+
+    REQUIRE(bbox.x2 - bbox.x1 == Approx(21.4));
+}
+
+TEST_CASE("text bbox estimates emoji as wide symbols", "[layout]") {
+    SVG::Text label(0, 0, std::string("\xf0\x9f\x98\x80"));
+    label.set_attr("font-size", 10);
+
+    const auto bbox = label.get_bbox();
+
+    REQUIRE(bbox.x2 - bbox.x1 == Approx(11.4));
 }
 
 TEST_CASE("autoscale includes text bounds", "[layout]") {
@@ -294,7 +362,7 @@ TEST_CASE("autoscale includes text bounds", "[layout]") {
 
     root.autoscale(SVG::NO_MARGINS);
 
-    REQUIRE(root.get_attr("viewBox") == "-10.0 -22.0 120.0 72.0");
+    REQUIRE(root.get_attr("viewBox") == "-13.4 -26.4 126.8 76.4");
 }
 
 TEST_CASE("explicit layout bbox lets autoscale use caller measurements", "[layout]") {
@@ -309,6 +377,33 @@ TEST_CASE("explicit layout bbox lets autoscale use caller measurements", "[layou
     REQUIRE(bad_bbox.x1 != bad_bbox.x1);
     REQUIRE(measured->layout_bbox().x1 == 10);
     REQUIRE(root.get_attr("viewBox") == "10.0 20.0 30.0 40.0");
+}
+
+TEST_CASE("explicit text layout bbox wins over measured padding", "[layout]") {
+    SVG::SVG root;
+    auto* label = root.add_child<SVG::Text>(0, 0, "Padded");
+    label->bbox_padding(100)
+        .layout_bbox({ 1, 2, 3, 4 });
+
+    root.autoscale(SVG::NO_MARGINS);
+
+    REQUIRE(label->layout_bbox().x1 == 1);
+    REQUIRE(label->layout_bbox().x2 == 2);
+    REQUIRE(root.get_attr("viewBox") == "1.0 3.0 1.0 1.0");
+}
+
+TEST_CASE("bbox padding inflates measured layout bounds", "[layout]") {
+    SVG::Text label(10, 20, "OK");
+    label.set_attr("font-size", 10);
+    label.bbox_padding({ 1, 2, 3, 4 });
+
+    const auto geometry = label.get_bbox();
+    const auto layout = label.layout_bbox();
+
+    REQUIRE(layout.x1 == Approx(geometry.x1 - 1));
+    REQUIRE(layout.x2 == Approx(geometry.x2 + 2));
+    REQUIRE(layout.y1 == Approx(geometry.y1 - 3));
+    REQUIRE(layout.y2 == Approx(geometry.y2 + 4));
 }
 
 TEST_CASE("clearing layout bbox restores built-in autoscale measurement", "[layout]") {

--- a/tests/layout_tests.cpp
+++ b/tests/layout_tests.cpp
@@ -261,6 +261,21 @@ TEST_CASE("text bbox approximates baseline text bounds", "[layout]") {
     REQUIRE(bbox.y2 == Approx(24));
 }
 
+TEST_CASE("empty text bbox collapses to positioned point", "[layout]") {
+    SVG::Text label(10, 20, "");
+    label.set_attr("dx", 3)
+        .set_attr("dy", -4)
+        .set_attr("stroke", "#111")
+        .set_attr("stroke-width", 2);
+
+    const auto bbox = label.get_bbox();
+
+    REQUIRE(bbox.x1 == Approx(12));
+    REQUIRE(bbox.x2 == Approx(14));
+    REQUIRE(bbox.y1 == Approx(15));
+    REQUIRE(bbox.y2 == Approx(17));
+}
+
 TEST_CASE("text bbox respects middle anchor and baseline", "[layout]") {
     SVG::Text title(50, 25, "Header");
     title.set_attr("font-size", 20)

--- a/tests/layout_tests.cpp
+++ b/tests/layout_tests.cpp
@@ -540,6 +540,51 @@ TEST_CASE("align_to defaults to center anchor", "[layout]") {
     REQUIRE(legend.get_attr("transform") == "translate(12.0 40.0)");
 }
 
+TEST_CASE("align_to supports start and end anchors", "[layout]") {
+    SVG::Rect plot(10, 20, 100, 50);
+    SVG::Group x_start;
+    SVG::Group x_end;
+    SVG::Group y_start;
+    SVG::Group y_end;
+    x_start.layout_bbox({ 0, 20, 0, 10 });
+    x_end.layout_bbox({ 0, 20, 0, 10 });
+    y_start.layout_bbox({ 0, 20, 0, 10 });
+    y_end.layout_bbox({ 0, 20, 0, 10 });
+
+    x_start.align_to(plot, SVG::Axis::X, SVG::Anchor::Start);
+    x_end.align_to(plot, SVG::Axis::X, SVG::Anchor::End);
+    y_start.align_to(plot, SVG::Axis::Y, SVG::Anchor::Start);
+    y_end.align_to(plot, SVG::Axis::Y, SVG::Anchor::End);
+
+    REQUIRE(x_start.get_attr("transform") == "translate(10.0 0.0)");
+    REQUIRE(x_end.get_attr("transform") == "translate(90.0 0.0)");
+    REQUIRE(y_start.get_attr("transform") == "translate(0.0 20.0)");
+    REQUIRE(y_end.get_attr("transform") == "translate(0.0 60.0)");
+}
+
+TEST_CASE("align_to rejects invalid axis or anchor", "[layout]") {
+    SVG::Rect plot(10, 20, 100, 50);
+    SVG::Group legend;
+    legend.layout_bbox({ 0, 20, 0, 10 });
+
+    REQUIRE_THROWS_AS(
+        legend.align_to(plot, static_cast<SVG::Axis>(99)),
+        std::invalid_argument);
+    REQUIRE_THROWS_AS(
+        legend.align_to(plot, SVG::Axis::X, static_cast<SVG::Anchor>(0)),
+        std::invalid_argument);
+}
+
+TEST_CASE("align_to rejects unmeasurable bounds", "[layout]") {
+    SVG::Rect plot(10, 20, 100, 50);
+    SVG::Rect label(0, 0, 20, 10);
+    BadBBoxElement source;
+    BadBBoxElement target;
+
+    REQUIRE_THROWS_AS(source.align_to(plot, SVG::Axis::X), std::logic_error);
+    REQUIRE_THROWS_AS(label.align_to(target, SVG::Axis::Y), std::logic_error);
+}
+
 TEST_CASE("merge combines SVG documents horizontally", "[layout]") {
     auto s1 = two_circles(200, 200, 200);
     auto s2 = two_circles(200, 200, 200);

--- a/tests/layout_tests.cpp
+++ b/tests/layout_tests.cpp
@@ -353,6 +353,33 @@ TEST_CASE("text bbox estimates emoji as wide symbols", "[layout]") {
     REQUIRE(bbox.x2 - bbox.x1 == Approx(11.4));
 }
 
+TEST_CASE("multiline text bbox uses longest line width", "[layout]") {
+    SVG::Text label(0, 0, "Hi\nMMMM");
+    label.set_attr("font-size", 10);
+
+    const auto bbox = label.get_bbox();
+
+    REQUIRE(bbox.x2 - bbox.x1 == Approx(37.2));
+    REQUIRE(bbox.y1 == Approx(-10.2));
+    REQUIRE(bbox.y2 == Approx(17.2));
+    REQUIRE(bbox.y2 - bbox.y1 == Approx(27.4));
+}
+
+TEST_CASE("multiline text bbox handles CRLF and blank lines", "[layout]") {
+    SVG::Text crlf(0, 0, "OK\r\nM");
+    SVG::Text blank_line(0, 0, "W\n\nW");
+    crlf.set_attr("font-size", 10);
+    blank_line.set_attr("font-size", 10);
+
+    const auto crlf_bbox = crlf.get_bbox();
+    const auto blank_line_bbox = blank_line.get_bbox();
+
+    REQUIRE(crlf_bbox.x2 - crlf_bbox.x1 == Approx(14.8));
+    REQUIRE(crlf_bbox.y2 - crlf_bbox.y1 == Approx(27.4));
+    REQUIRE(blank_line_bbox.x2 - blank_line_bbox.x1 == Approx(9.6));
+    REQUIRE(blank_line_bbox.y2 - blank_line_bbox.y1 == Approx(40.6));
+}
+
 TEST_CASE("autoscale includes text bounds", "[layout]") {
     SVG::SVG root;
     root.add_child<SVG::Rect>(0, 0, 100, 50);

--- a/tests/style_tests.cpp
+++ b/tests/style_tests.cpp
@@ -255,4 +255,10 @@ TEST_CASE("Typed CSS classes reject ambiguous or invalid names", "[style]") {
     REQUIRE_THROWS_AS(SVG::Classes<PlotClass>({
         { PlotClass::axis_line, "axis line" }
     }), std::invalid_argument);
+    REQUIRE_THROWS_AS(SVG::Classes<PlotClass>({
+        { PlotClass::axis_line, "" }
+    }), std::invalid_argument);
+    REQUIRE_THROWS_AS(SVG::Classes<PlotClass>({
+        { PlotClass::axis_line, "." }
+    }), std::invalid_argument);
 }

--- a/tests/style_tests.cpp
+++ b/tests/style_tests.cpp
@@ -97,6 +97,16 @@ TEST_CASE("Color helpers preserve palette relationships", "[style]") {
     REQUIRE(static_cast<std::string>(SVG::Color::black()) == "#000000");
 }
 
+TEST_CASE("HSL colors cover hue sectors and wrapping", "[style]") {
+    REQUIRE(static_cast<std::string>(SVG::Color::hsl(-60, 100, 50)) == "#ff00ff");
+    REQUIRE(static_cast<std::string>(SVG::Color::hsl(30, 100, 50)) == "#ff8000");
+    REQUIRE(static_cast<std::string>(SVG::Color::hsl(90, 100, 50)) == "#80ff00");
+    REQUIRE(static_cast<std::string>(SVG::Color::hsl(150, 100, 50)) == "#00ff80");
+    REQUIRE(static_cast<std::string>(SVG::Color::hsl(210, 100, 50)) == "#0080ff");
+    REQUIRE(static_cast<std::string>(SVG::Color::hsl(270, 100, 50)) == "#8000ff");
+    REQUIRE(static_cast<std::string>(SVG::Color::hsl(390, 100, 50)) == "#ff8000");
+}
+
 TEST_CASE("Color helpers reject invalid values", "[style]") {
     REQUIRE_THROWS_AS(SVG::Color::rgb(-1, 0, 0), std::invalid_argument);
     REQUIRE_THROWS_AS(SVG::Color::rgb(0, 256, 0), std::invalid_argument);

--- a/tests/style_tests.cpp
+++ b/tests/style_tests.cpp
@@ -208,6 +208,7 @@ TEST_CASE("Typed CSS variables reject ambiguous mappings and bad formats", "[sty
     REQUIRE_THROWS_AS(vars.format("calc({0} * {1})", PlotVar::axis), std::invalid_argument);
     REQUIRE_THROWS_AS(vars.format("calc({0})", PlotVar::axis, PlotVar::text_size), std::invalid_argument);
     REQUIRE_THROWS_AS(vars.format("calc({0)", PlotVar::axis), std::invalid_argument);
+    REQUIRE_THROWS_AS(vars.format("calc({0})}", PlotVar::axis), std::invalid_argument);
 }
 
 TEST_CASE("Typed CSS classes produce selectors and class attributes", "[style]") {

--- a/tests/traversal_tests.cpp
+++ b/tests/traversal_tests.cpp
@@ -2,6 +2,17 @@
 #include "svg.hpp"
 #include "test_helpers.hpp"
 
+namespace {
+    class ClearableGroup : public SVG::Group {
+    public:
+        using SVG::Group::Group;
+
+        void clear_for_test() {
+            clear_children();
+        }
+    };
+}
+
 TEST_CASE("get_children returns descendants by tag", "[traversal]") {
     SVG::SVG root;
     auto circ_ptr = root.add_child<SVG::Circle>();
@@ -211,6 +222,23 @@ TEST_CASE("Moved subtrees register ids with their new SVG root", "[traversal]") 
     rect->id("attached");
     REQUIRE(root.get_element_by_id("detached") == nullptr);
     REQUIRE(root.get_element_by_id("attached") == rect);
+}
+
+TEST_CASE("Clearing children unregisters descendant ids", "[traversal]") {
+    SVG::SVG root;
+    auto* group = root.add_child<ClearableGroup>();
+    group->add_child<SVG::Rect>();
+    auto* child = group->add_child<SVG::Group>("child");
+    child->add_child<SVG::Rect>("leaf");
+
+    REQUIRE(root.get_element_by_id("child") == child);
+    REQUIRE(root.get_element_by_id("leaf") != nullptr);
+
+    group->clear_for_test();
+
+    REQUIRE(group->get_immediate_children<SVG::Element>().empty());
+    REQUIRE(root.get_element_by_id("child") == nullptr);
+    REQUIRE(root.get_element_by_id("leaf") == nullptr);
 }
 
 TEST_CASE("get_elements_by_class matches tokenized classes", "[traversal]") {


### PR DESCRIPTION
- Added more accurate character/Unicode-aware size estimations for `SVG::Text`
- Added `get_attr<T>` supporting numeric `T` with a fallback
- Expanded test coverage